### PR TITLE
Fix for issue running tests with newlines in their name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.vscode-test
 node_modules
 out

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,6 +18,20 @@
       "request": "attach",
       "name": "Mocha worker",
       "processId": "${command:PickProcess}"
+    },
+    {
+      "name": "Extension Tests",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+          "--extensionDevelopmentPath=${workspaceFolder}",
+          "--extensionTestsPath=${workspaceFolder}/out/test"
+      ],
+      "outFiles": [
+          "${workspaceFolder}/out/test/**/*.js"
+      ],
+      "preLaunchTask": "npm: watch"
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,8 +8,20 @@
             "problemMatcher": [
                 "$tsc-watch"
             ],
-            "label": "Watch Mocha",
-            "auto": true
+            "label": "Watch Mocha"
+        },
+        {
+            "type": "npm",
+            "script": "watch",
+            "problemMatcher": "$tsc-watch",
+            "isBackground": true,
+            "presentation": {
+                "reveal": "never"
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ If the Test view doesn't show your tests or anything else doesn't work as expect
 * `mochaExplorer.logpanel`: Write diagnotic logs to an output panel
 * `mochaExplorer.logfile`: Write diagnostic logs to the given file
 
-There is a [bug in Node >= 10.6](https://github.com/nodejs/node/issues/21671) that breaks this adapter.
+There is a [bug in Node 10.6.0 - 10.9.0](https://github.com/nodejs/node/issues/21671) that breaks this adapter.
 If you're using a version of Node affected by this bug, add `"mochaExplorer.nodePath": null` to your configuration as a workaround.
 
 If you think you've found a bug, please [file a bug report](https://github.com/hbenl/vscode-mocha-test-adapter/issues) and attach the diagnostic logs.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "build": "tsc",
     "watch": "tsc -w",
     "rebuild": "npm run clean && npm run build",
+    "test": "npm run build && node ./node_modules/vscode/bin/test",
     "package": "vsce package",
     "publish": "vsce publish"
   },

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -175,7 +175,7 @@ export class MochaAdapter implements TestAdapter, IDisposable {
 					}
 				});
 
-				childProc.on('exit', () => {
+				childProc.on('close', () => {
 					this.log.info('Worker finished');
 					if (!testsLoaded) {
 						this.testsEmitter.fire(<TestLoadFinishedEvent>{ type: 'finished', suite: undefined });

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1,0 +1,67 @@
+import * as assert from 'assert';
+import * as Path from 'path';
+import * as vscode from 'vscode';
+import { TestSuiteInfo } from 'vscode-test-adapter-api';
+import { Log } from 'vscode-test-adapter-util';
+
+import { MochaAdapter } from '../adapter';
+
+const PROJECT_ROOT = Path.join(__dirname, '../../');
+const WORKSPACES_ROOT = Path.join(PROJECT_ROOT, 'src/test/workspaces/');
+
+suite("Extension Tests", function () {
+
+    // verify that tests whose titles contain '\n' are loaded and run properly
+    test("should handle test titles containing newlines properly", async function() {
+        this.timeout(10000);
+
+        // create Mocha adapter
+        const adapter = createMochaAdapter('newlines');
+
+        // load tests, storing discovered suite
+        let suites: TestSuiteInfo[] = [];
+        adapter.tests((e) => {
+            if (e.type === 'finished' && e.suite) {
+                suites.push(e.suite);
+            }
+        });
+
+        await adapter.load();
+
+        // verify the appropriate number of tests were found (3)
+        assert.strictEqual(suites.length, 1);
+        assert.strictEqual(suites[0].children.length, 1);
+        assert.strictEqual(suites[0].children[0].type, 'suite');
+
+        const suite = suites[0].children[0] as TestSuiteInfo;
+        assert.strictEqual(suite.children.length, 3);
+
+        // run a test with a newline in its title, verifying that only it was run.
+        // previously there was a bug where everything after the newline was ignored,
+        // causing multiple tests to be picked up when only one was specified.
+        let numTestsRun = 0;
+        adapter.testStates((e) => {
+            if (e.type === 'test' && e.state === 'running') {
+                numTestsRun++;
+            }
+        });
+
+        await adapter.run([suite.children[1].id]);
+
+        assert.strictEqual(numTestsRun, 1);
+    });
+});
+
+function createMochaAdapter(testWorkspaceName: string) {
+    const workspaceFolder: vscode.WorkspaceFolder = {
+        uri: vscode.Uri.file(Path.join(WORKSPACES_ROOT, testWorkspaceName)),
+        name: testWorkspaceName,
+        index: 0
+    };
+    const outputChannel = vscode.window.createOutputChannel('Mocha Tests');
+    const log = new Log('mochaExplorer', workspaceFolder, 'Mocha Explorer Log');
+
+    vscode.workspace.updateWorkspaceFolders(0, null, workspaceFolder);
+
+    return new MochaAdapter(workspaceFolder, outputChannel, log);
+}

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -1,0 +1,22 @@
+//
+// PLEASE DO NOT MODIFY / DELETE UNLESS YOU KNOW WHAT YOU ARE DOING
+//
+// This file is providing the test runner to use when running extension tests.
+// By default the test runner in use is Mocha based.
+//
+// You can provide your own test runner if you want to override it by exporting
+// a function run(testRoot: string, clb: (error:Error) => void) that the extension
+// host can call to run the tests. The test runner is expected to use console.log
+// to report the results back to the caller. When the tests are finished, return
+// a possible error to the callback or null if none.
+
+import * as testRunner from 'vscode/lib/testrunner';
+
+// You can directly control Mocha options by uncommenting the following lines
+// See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
+testRunner.configure({
+    ui: 'tdd', 		// the TDD UI is being used in extension.test.ts (suite, test, etc.)
+    useColors: true // colored output from test results
+});
+
+module.exports = testRunner;

--- a/src/test/workspaces/newlines/test/tests.js
+++ b/src/test/workspaces/newlines/test/tests.js
@@ -1,0 +1,15 @@
+var assert = require('assert');
+
+describe('tests', function() {
+	it('ABC\n123', function() {
+		assert.notStrictEqual(1, 2);
+	});
+
+	it('ABC\n	456', function() {
+		assert.notStrictEqual(1, 2);
+	});
+
+	it('ABC\n\t789', function() {
+		assert.notStrictEqual(1, 2);
+	});
+});

--- a/src/worker/runTests.ts
+++ b/src/worker/runTests.ts
@@ -18,7 +18,7 @@ try {
 
 	const Mocha: typeof import('mocha') = require(mochaPath);
 
-	const regExp = testsToRun.map(RegExEscape).join('|');
+	const regExp = new RegExp(testsToRun.map(RegExEscape).join('|'));
 
 	const cwd = process.cwd();
 	module.paths.push(cwd, path.join(cwd, 'node_modules'));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "src/main.ts",
     "src/worker/mocha-private.d.ts",
     "src/worker/loadTests.ts",
-    "src/worker/runTests.ts"
+    "src/worker/runTests.ts",
+    "src/test/**/*.ts"
   ]
 }
   


### PR DESCRIPTION
This resolves an issue with running tests with newlines in their names. Previously, if you had multiple tests with newlines in their names where the part before the newline was the same, such as:

`someFunc\nVariation 1`
`someFunc\nVariation 2`
`someFunc\nVariation 3`

Then if you tried to run just one of those tests through the Test Explorer, all of those tests would be run instead of just the one you wanted.

This PR resolves that (single line fix), as well as adding a unit test to verify the fix.