### PR TITLE
Separate "test files" from "files to load for each test"

### DIFF
--- a/src/configKeys.ts
+++ b/src/configKeys.ts
@@ -18,6 +18,7 @@ const rawConfigKeys: { [key: string]: { onChange?: OnChange } } = {
 	timeout: { onChange: 'retire' },
 	retries: { onChange: 'retire' },
 	require: { onChange: 'reloadTests' },
+	file: { },
 	exit: { onChange: 'reloadConfig' },
 	optsFile: { onChange: 'reloadTests' },
 	nodePath: { onChange: 'reloadTests' },

--- a/src/optsReader.ts
+++ b/src/optsReader.ts
@@ -7,7 +7,6 @@ import { ILog } from './core';
 export interface MochaOptsAndFiles {
 	mochaOpts: Partial<MochaOpts>;
 	globs: string[];
-	files: string[];
 }
 
 export class MochaOptsReader {
@@ -72,7 +71,7 @@ export class MochaOptsReader {
 							this.log.debug(`Couldn't read mocha.opts file: ${util.inspect(err)}`);
 						}
 					}
-					resolve({ mochaOpts: {}, globs: [], files: [] });
+					resolve({ mochaOpts: {}, globs: [] });
 					return;
 				}
 
@@ -94,18 +93,18 @@ export class MochaOptsReader {
 					const requires = this.findOptValues(['-r', '--require'], opts);
 					const exit = (opts.indexOf('--exit') >= 0) ? true : undefined;
 
-					const mochaOpts = { ui, timeout, retries, requires, exit };
+					const mochaOpts = { ui, timeout, retries, requires, exit, files };
 					if (this.log.enabled) {
 						this.log.debug(`Options from mocha.opts file: ${JSON.stringify(mochaOpts)}`);
 						this.log.debug(`Globs from mocha.opts file: ${JSON.stringify(globs)}`);
 						this.log.debug(`Files from mocha.opts file: ${JSON.stringify(files)}`);
 					}
 
-					resolve({ mochaOpts, globs, files });
+					resolve({ mochaOpts, globs });
 
 				} catch (err) {
 					if (this.log.enabled) this.log.debug(`Couldn't parse mocha.opts file: ${util.inspect(err)}`);
-					resolve({ mochaOpts: {}, globs: [], files: [] });
+					resolve({ mochaOpts: {}, globs: [] });
 				}
 			});
 		});
@@ -150,14 +149,14 @@ export class MochaOptsReader {
 		});
 
 		return {
-			files: options.file || [],
 			globs: options._ || [],
 			mochaOpts: {
 				ui: options.ui,
 				requires: options.require,
 				timeout: +options.timeout,
 				retries: (options.retries !== undefined) ? +options.retries : undefined,
-				exit: options.exit
+				exit: options.exit,
+				files: options.file || [],
 			}
 		}
 	}

--- a/src/test/adapter.ts
+++ b/src/test/adapter.ts
@@ -25,7 +25,8 @@ export async function createTestMochaAdapter(
 		timeout: mochaOptsAndFiles.mochaOpts.timeout || 1000,
 		retries: mochaOptsAndFiles.mochaOpts.retries || 0,
 		requires: mochaOptsAndFiles.mochaOpts.requires || [],
-		exit: mochaOptsAndFiles.mochaOpts.exit || false
+		exit: mochaOptsAndFiles.mochaOpts.exit || false,
+		files: mochaOptsAndFiles.mochaOpts.files || [],
 	};
 	const relativeGlob = mochaOptsAndFiles.globs[0] || 'test/**/*.js';
 	const absoluteGlob = path.resolve(workspaceFolderPath, relativeGlob);

--- a/src/worker/main.ts
+++ b/src/worker/main.ts
@@ -94,7 +94,11 @@ function execute(args: WorkerArgs, sendMessage: (message: any) => Promise<void>,
 		mocha.timeout(args.mochaOpts.timeout);
 		mocha.suite.retries(args.mochaOpts.retries);
 
-		if (logEnabled) sendMessage('Loading files');
+		if (logEnabled) sendMessage(`Loading extra files ${args.mochaOpts.files}`);
+		for (const file of args.mochaOpts.files) {
+			mocha.addFile(file);
+		}
+		if (logEnabled) sendMessage(`Loading test files ${args.testFiles}`);
 		for (const file of args.testFiles) {
 			mocha.addFile(file);
 		}


### PR DESCRIPTION
The `--file` argument is used for configuring files that need to be loaded as part of running any
set of tests, and these are intended to add global hooks etc.

For that reason these need to be kept separate (in the mochaOpts) from the actual test files, and the
worker needs to explicitly load them when running a set of tests.

---
NOTE: This needs https://github.com/hbenl/vscode-test-adapter-remoting-util/pull/1, I wasn't sure how to avoid the API change there.