### PR TITLE
fix: load test files which may be hidden by VS Code

### DIFF
--- a/src/configReader.ts
+++ b/src/configReader.ts
@@ -219,7 +219,7 @@ export class ConfigReader implements IConfigReader, IDisposable {
 		}
 
 		const relativePattern = new vscode.RelativePattern(this.workspaceFolder, 'test/**/*.js');
-		const fileUris = await vscode.workspace.findFiles(relativePattern, 'node_modules');
+		const fileUris = await vscode.workspace.findFiles(relativePattern, null);
 		if (fileUris.length > 0) {
 
 			let msg = `The workspace folder ${this.workspaceFolder.name} contains test files, but I'm not sure if they should be run using Mocha. `;
@@ -290,7 +290,7 @@ export class ConfigReader implements IConfigReader, IDisposable {
 				testFilesGlob = testFilesGlob.substring(2);
 			}
 			const relativePattern = new vscode.RelativePattern(this.workspaceFolder, testFilesGlob);
-			const fileUris = await vscode.workspace.findFiles(relativePattern, 'node_modules');
+			const fileUris = await vscode.workspace.findFiles(relativePattern, null);
 			testFiles.push(...fileUris.map(uri => uri.fsPath));
 		}
 


### PR DESCRIPTION

By supplying `null` to the `.findFiles()` method we are telling VS Code to not ignore anything (default behaviour is to use "default" ignore patterns which includes files hidden from VS Code's Explroer using VS Code's `files.exclude` setting.

This setting is, however, frequently used to hide compiled files, but at the same time these files are then used to run the test suite.

This potentially a breaking change as now, by default, even test files inside *node_modules* might be executed. This is easily fixed by using a folder prefix on the test files pattern, ie: `{src,test}/**/*.test.js`.

Fixes #103