### PR TITLE
add root hook support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-mocha-test-adapter",
-  "version": "2.7.0",
+  "version": "2.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1134,9 +1134,9 @@
       "dev": true
     },
     "@types/mocha": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.0.0.tgz",
-      "integrity": "sha512-jWeYcTo3sCH/rMgsdYXDTO85GNRyTCII5dayMIu/ZO4zbEot1E3iNGaOwpLReLUHjeNQFkgeNNVYlY4dX6azQQ==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.0.3.tgz",
+      "integrity": "sha512-vyxR57nv8NfcU0GZu8EUXZLTbCMupIUwy95LJ6lllN+JRPG25CwMHoB1q5xKh8YKhQnHYRAn4yW2yuHbf/5xgg==",
       "dev": true
     },
     "@types/node": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@types/diff": "^4.0.2",
     "@types/glob": "^7.1.3",
     "@types/minimatch": "^3.0.3",
-    "@types/mocha": "^8.0.0",
+    "@types/mocha": "^8.0.3",
     "@types/node": "^12.12.53",
     "@types/source-map-support": "^0.5.2",
     "@types/split": "^1.0.0",


### PR DESCRIPTION
Add root hook support by calling rootHooks with all required modules (mochaOpts.requires) which export mochaHooks.

closes #127