### PR TITLE
Fix issues with path convention mismatches on Windows

### DIFF
--- a/src/test/babel.test.ts
+++ b/src/test/babel.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import { createTestMochaAdapter } from "./adapter";
-import { getExpectedTests, getExpectedTestRunEvents } from './expectedTests';
+import { getExpectedTests, getExpectedTestRunEvents, removeStackTraces } from './expectedTests';
 
 describe("Babel tests", function() {
 
@@ -27,6 +27,8 @@ describe("Babel tests", function() {
 		await adapter.run([ rootSuite!.id ]);
 
 		const expectedTestRunEvents = getExpectedTestRunEvents(workspaceFolderName);
-		assert.deepStrictEqual(adapter.getTestRunEvents(), expectedTestRunEvents);
+		assert.deepStrictEqual(
+			removeStackTraces(adapter.getTestRunEvents()), 
+			removeStackTraces(expectedTestRunEvents));
 	});
 });

--- a/src/test/esm.test.ts
+++ b/src/test/esm.test.ts
@@ -26,7 +26,9 @@ describe("ESM tests using the esm package from npm", function() {
 		const rootSuite = adapter.getLoadedTests();
 		await adapter.run([ rootSuite!.id ]);
 
-		assert.deepStrictEqual(adapter.getTestRunEvents(), getExpectedTestRunEvents(workspaceFolderName));
+		assert.deepStrictEqual(
+			removeStackTraces(adapter.getTestRunEvents()), 
+			removeStackTraces(getExpectedTestRunEvents(workspaceFolderName)));
 	});
 });
 

--- a/src/test/loadAndRun.test.ts
+++ b/src/test/loadAndRun.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import { createTestMochaAdapter } from './adapter';
-import { getExpectedTests, getExpectedTestRunEvents } from './expectedTests';
+import { getExpectedTests, getExpectedTestRunEvents, removeStackTraces } from './expectedTests';
 
 describe("Loading tests", function() {
 
@@ -33,7 +33,9 @@ describe("Running tests", function() {
 			const rootSuite = adapter.getLoadedTests();
 			await adapter.run([ rootSuite!.id ]);
 
-			assert.deepStrictEqual(adapter.getTestRunEvents(), getExpectedTestRunEvents(workspaceFolderName));
+			assert.deepStrictEqual(
+				removeStackTraces(adapter.getTestRunEvents()), 
+				removeStackTraces(getExpectedTestRunEvents(workspaceFolderName)));
 		});
 	}
 });

--- a/src/test/sourcemapSupport.test.ts
+++ b/src/test/sourcemapSupport.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import { createTestMochaAdapter } from "./adapter";
-import { getExpectedTests, getExpectedTestRunEvents } from './expectedTests';
+import { getExpectedTests, getExpectedTestRunEvents, removeStackTraces } from './expectedTests';
 
 describe("Sourcemapped tests", function() {
 
@@ -26,6 +26,8 @@ describe("Sourcemapped tests", function() {
 		const rootSuite = adapter.getLoadedTests();
 		await adapter.run([ rootSuite!.id ]);
 
-		assert.deepStrictEqual(adapter.getTestRunEvents(), getExpectedTestRunEvents(workspaceFolderName));
+		assert.deepStrictEqual(
+			removeStackTraces(adapter.getTestRunEvents()), 
+			removeStackTraces(getExpectedTestRunEvents(workspaceFolderName)));
 	});
 });

--- a/src/test/typescript.test.ts
+++ b/src/test/typescript.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import { createTestMochaAdapter } from "./adapter";
-import { getExpectedTests, getExpectedTestRunEvents } from './expectedTests';
+import { getExpectedTests, getExpectedTestRunEvents, removeStackTraces } from './expectedTests';
 
 describe("Typescript tests", function() {
 
@@ -26,6 +26,8 @@ describe("Typescript tests", function() {
 		const rootSuite = adapter.getLoadedTests();
 		await adapter.run([ rootSuite!.id ]);
 
-		assert.deepStrictEqual(adapter.getTestRunEvents(), getExpectedTestRunEvents(workspaceFolderName));
+		assert.deepStrictEqual(
+			removeStackTraces(adapter.getTestRunEvents()), 
+			removeStackTraces(getExpectedTestRunEvents(workspaceFolderName)));
 	});
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,6 @@
 import * as fs from 'fs';
+import url from 'url';
+import path from 'path';
 import { TestInfo, TestSuiteInfo } from 'vscode-test-adapter-api';
 
 export function fileExists(path: string): Promise<boolean> {
@@ -54,3 +56,28 @@ export function stringsOnly(env: { [envVar: string]: string | null | undefined }
 	}
 	return result;
 }
+
+export function normalizePathOrFileUrlToPath(p: string): string {
+	if (p?.startsWith("file://")) {
+		p = url.fileURLToPath(p);
+	}
+	return normalizePath(p);
+}
+
+export function normalizePath(p: string): string {
+	if (!p) {
+		return p;
+	}
+	if (process.platform === 'win32') {
+		// On Windows, normalize drive letter to upper case. Works around
+		// https://github.com/microsoft/vscode/issues/68325. A mismatch in
+		// the drive letter case can cause node to load the same module
+		// twice. 
+		const match = /^([a-z]):/.exec(p);
+		if (match) {
+			p = match[1].toUpperCase() + p.substr(1);
+		}
+	}
+	return path.normalize(p);
+}
+

--- a/src/worker/patchMocha.ts
+++ b/src/worker/patchMocha.ts
@@ -1,5 +1,8 @@
+import path from 'path';
 import os from 'os';
 import stackTrace from 'stack-trace';
+import url from 'url';
+import { normalizePath, normalizePathOrFileUrlToPath } from '../util';
 
 export interface Location {
 	file: string;
@@ -124,9 +127,7 @@ function findCallLocation(
 			const stackFrame = stackFrames[i];
 			let filename = stackFrame.getFileName();
 			if (typeof filename === 'string') {
-				if (filename.startsWith('file://')) {
-					filename = filename.substring((os.platform() === 'win32') ? 8 : 7);
-				}
+				filename = normalizePathOrFileUrlToPath(filename);
 				if (filename === runningFile) {
 					return { file: runningFile, line: stackFrame.getLineNumber() - 1 };
 				}
@@ -140,7 +141,7 @@ function findCallLocation(
 		if (baseDir) {
 			for (var i = 0; i < stackFrames.length - 1; i++) {
 				const stackFrame = stackFrames[i];
-				const file = stackFrame.getFileName();
+				const file = normalizePathOrFileUrlToPath(stackFrame.getFileName());
 				if (file.startsWith(baseDir)) {
 					return { file, line: stackFrame.getLineNumber() - 1 };
 				}

--- a/src/worker/reporter.ts
+++ b/src/worker/reporter.ts
@@ -4,6 +4,7 @@ import stackTrace from 'stack-trace';
 import { createPatch } from 'diff';
 import { TestEvent, TestSuiteEvent, TestDecoration } from 'vscode-test-adapter-api';
 import { retrieveSourceMap } from 'source-map-support';
+import { normalizePath, normalizePathOrFileUrlToPath } from '../util';
 
 export default (sendMessage: (message: any) => void, stringify: (obj: any) => string, useSourceMapSupport: boolean) => {
 
@@ -95,11 +96,8 @@ export default (sendMessage: (message: any) => void, stringify: (obj: any) => st
 				if (err.stack) {
 					const parsedStack = stackTrace.parse(err);
 					for (const stackFrame of parsedStack) {
-						let filename = stackFrame.getFileName();
+						let filename = normalizePathOrFileUrlToPath(stackFrame.getFileName());
 						if (typeof filename === 'string') {
-							if (filename.startsWith('file://')) {
-								filename = filename.substring((os.platform() === 'win32') ? 8 : 7);
-							}
 							filename = path.resolve(filename);
 							let matchFound = false;
 							if (useSourceMapSupport && test.file) {


### PR DESCRIPTION
1. Sourcemap support sometimes failed to locate .ts file if the stack trace had different path conventions than the base directory. In these cases, double clicking on a test navigated to .js instead of .ts file.

2. Drive letter was being lowercased by VS Code, which could cause node.js to load two copies of the same the module (one for lowercase drive letter and one for uppercase), which could then cause user tests to behave unexpectedly and fail.

3. Before this change, many tests were failing on Windows due to related path convention issues. Tests are now completely passing on Windows. This also required removing stack traces from test comparisons in more places.
