### PR TITLE
Removes vscode-test-explorer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Mocha Test Explorer for Visual Studio Code
 
-Run your Mocha tests using the 
-[Test Explorer UI](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-test-explorer).
+Run your Mocha tests using the
+[Vscode Testing API](https://code.visualstudio.com/api/extension-guides/testing).
 
 ![Screenshot](img/screenshot.png)
 

--- a/package.json
+++ b/package.json
@@ -37,9 +37,7 @@
     "package": "vsce package",
     "publish": "vsce publish"
   },
-  "extensionDependencies": [
-    "hbenl.vscode-test-explorer"
-  ],
+  "extensionDependencies": [],
   "dependencies": {
     "chokidar": "^3.5.2",
     "diff": "^5.0.0",


### PR DESCRIPTION
This commit removes the dependency to the [vscode-test-explorer](https://github.com/hbenl/vscode-test-explorer#migrating-to-native-testing) since it will be deprecated now the vscode test API has been finalized (see [this announcement](ttps://github.com/hbenl/vscode-test-explorer#migrating-to-native-testing)).

#### Warning

I tried building this extension, but I received the following errors:

```bash
src/core.ts:354:115 - error TS2571: Object is of type 'unknown'.

354       this.testsEmitter.fire(<TestLoadFinishedEvent>{ type: 'finished', errorMessage: `Couldn't establish IPC:\n${err.stack}` });
```

I don't think there are related to the code changes I made are related, but please double-check and fix them before merging this. Because of some pressing deadlines, I sadly don't have time to investigate this futher.

