### PR TITLE
fix inability to run TypeScript tests in parallel

### DIFF
--- a/src/worker/main.ts
+++ b/src/worker/main.ts
@@ -130,7 +130,7 @@ async function execute(args: WorkerArgs, sendMessage: (message: any) => Promise<
 			}
 		}
 
-		const mocha = new Mocha();
+		const mocha = new Mocha({ require: args.mochaOpts.requires });
 
 		mocha.ui(args.mochaOpts.ui);
 		mocha.timeout(args.mochaOpts.timeout);


### PR DESCRIPTION
ensure 'requires' are passed down through Mocha options to parallel workers