### PR TITLE
fixed globFiles to utilize cwd

### DIFF
--- a/src/configReader.ts
+++ b/src/configReader.ts
@@ -491,7 +491,8 @@ export class ConfigReader implements IConfigReader, IDisposable {
 	private async globFiles(config: vscode.WorkspaceConfiguration, relativeGlob: string) {
 		if (this.getGlobImplementation(config) === 'glob') {
 
-			const absoluteGlob = normalizePath(path.resolve(this.workspaceFolder.uri.fsPath, relativeGlob));
+			const cwdRelativeGlob = config.cwd ? path.join(config.cwd, relativeGlob) : relativeGlob;
+			const absoluteGlob = normalizePath(path.resolve(this.workspaceFolder.uri.fsPath, cwdRelativeGlob));
 			return await new Promise<string[]>(
 				(resolve, reject) => glob(
 					absoluteGlob,


### PR DESCRIPTION
I had a working with more than one node app under the root.

- root
  - server
     - src
  - client

Whenever I tried to load tests from root directory, it failed to locate tests due to my glob pattern being `src/**/*.` and my cwd being `server` (cause that's where my ts-node was installed). 

so I fixed globFiles to consider `cwd` when trying to find files.