### PR TITLE
fix: pick correct frame when looking for test locations

### DIFF
--- a/src/worker/patchMocha.ts
+++ b/src/worker/patchMocha.ts
@@ -141,7 +141,7 @@ function findCallLocation(
 				let file = stackFrame.getFileName();
 				if (typeof file === 'string') {
 					file = normalizePathOrFileUrlToPath(file);
-					if (file.startsWith(baseDir)) {
+					if (file.startsWith(baseDir) && !file.includes('node_modules')) {
 						return { file, line: stackFrame.getLineNumber() - 1 };
 					}
 				}


### PR DESCRIPTION
The test locations were not selected correctly because they ended up somewhere inside Mocha's `describe` and `it` function definitions, since those functions are called last when constructing the stack frames to find the call sites. When I then tried to open the test file I always ended up at the same and incorrect place.

Note that this has further implications - test failures were also not being attributed to the correct test location in my code before this patch as they again ended up inside Mocha's function definitions.

Here is a sample stack trace that is produced when the adapter is looking for the test location:

```
[2022-10-07 10:25:31.164] [INFO] Worker: Looking for /Users/robert/repos/strv/enter/enter-backend in Error: 
    at findCallLocation (/Users/robert/.vscode/extensions/hbenl.vscode-mocha-test-adapter-2.14.1/out/worker/bundle.js:918:17)
    at /Users/robert/.vscode/extensions/hbenl.vscode-mocha-test-adapter-2.14.1/out/worker/bundle.js:909:30
⚠️  at exports.describe (/Users/robert/repos/strv/enter/enter-backend/node_modules/mocha/lib/mocha.js:111:60)
    at Object.<anonymous> (/Users/robert/repos/strv/enter/enter-backend/test/rest/root.e2e-spec.ts:6:9)
    at Module._compile (node:internal/modules/cjs/loader:1119:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1173:10)
    at Module.load (node:internal/modules/cjs/loader:997:32)
    at Function.Module._load (node:internal/modules/cjs/loader:838:12)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:170:29)
    at ModuleJob.run (node:internal/modules/esm/module_job:193:25)
```

This is expected; you do call `describe` and `it` functions from Mocha before you call your assertions. We therefore need to ignore call sites from the `node_modules` folder and go deeper.

Here are some screenshots of before and after this change:

#### Before

![before](https://user-images.githubusercontent.com/3058150/194534623-c42aa445-0a19-44aa-87af-8faffcf086c6.jpg)

#### After

![after](https://user-images.githubusercontent.com/3058150/194534641-aedccb0c-bcdf-4a28-9ec6-5bcf1a65f810.jpg)

