### PR TITLE
Support for the `extends` Config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-mocha-test-adapter",
-  "version": "2.13.5",
+  "version": "2.14.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-mocha-test-adapter",
-      "version": "2.13.5",
+      "version": "2.14.1",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",
@@ -22,7 +22,8 @@
         "tslib": "^2.4.0",
         "vscode-test-adapter-api": "^1.9.0",
         "vscode-test-adapter-remoting-util": "^0.13.0",
-        "vscode-test-adapter-util": "^0.7.1"
+        "vscode-test-adapter-util": "^0.7.1",
+        "yargs": "^16.2.0"
       },
       "devDependencies": {
         "@babel/core": "^7.18.6",
@@ -39,6 +40,7 @@
         "@types/split": "^1.0.1",
         "@types/stack-trace": "^0.0.30",
         "@types/vscode": "~1.47.0",
+        "@types/yargs": "^16.0.5",
         "esm": "^3.2.25",
         "mocha-prepare": "^0.1.0",
         "rimraf": "^3.0.2",
@@ -1905,6 +1907,21 @@
       "version": "1.47.0",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.47.0.tgz",
       "integrity": "sha512-nJA37ykkz9FYA0ZOQUSc3OZnhuzEW2vUhUEo4MiduUo82jGwwcLfyvmgd/Q7b0WrZAAceojGhZybg319L24bTA==",
+      "dev": true
+    },
+    "node_modules/@types/yargs": {
+      "version": "16.0.5",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.5.tgz",
+      "integrity": "sha512-AxO/ADJOBFJScHbWhq2xAhlWP24rY4aCEG/NFaMvbT3X2MgRsLjhjQwsn0Zi5zn0LG9jUhCCZMeX9Dkuw6k+vQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
+      "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
     },
     "node_modules/@ungap/promise-all-settled": {
@@ -6421,6 +6438,21 @@
       "version": "1.47.0",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.47.0.tgz",
       "integrity": "sha512-nJA37ykkz9FYA0ZOQUSc3OZnhuzEW2vUhUEo4MiduUo82jGwwcLfyvmgd/Q7b0WrZAAceojGhZybg319L24bTA==",
+      "dev": true
+    },
+    "@types/yargs": {
+      "version": "16.0.5",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.5.tgz",
+      "integrity": "sha512-AxO/ADJOBFJScHbWhq2xAhlWP24rY4aCEG/NFaMvbT3X2MgRsLjhjQwsn0Zi5zn0LG9jUhCCZMeX9Dkuw6k+vQ==",
+      "dev": true,
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
+      "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
     },
     "@ungap/promise-all-settled": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "tslib": "^2.4.0",
     "vscode-test-adapter-api": "^1.9.0",
     "vscode-test-adapter-remoting-util": "^0.13.0",
-    "vscode-test-adapter-util": "^0.7.1"
+    "vscode-test-adapter-util": "^0.7.1",
+    "yargs": "^16.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.18.6",
@@ -71,6 +72,7 @@
     "@types/split": "^1.0.1",
     "@types/stack-trace": "^0.0.30",
     "@types/vscode": "~1.47.0",
+    "@types/yargs": "^16.0.5",
     "esm": "^3.2.25",
     "mocha-prepare": "^0.1.0",
     "rimraf": "^3.0.2",

--- a/src/test/optsReader.test.ts
+++ b/src/test/optsReader.test.ts
@@ -64,4 +64,14 @@ describe("The OptsReader", function() {
 			ignores: [ 'test/*.no-test.js' ]
 		});
 	});
+
+	it("should load inherited settings", async function() {
+		const optsReader = new MochaOptsReader(new TestLog());
+
+		const optsAndFiles = await optsReader.readOptsUsingMocha(path.resolve(__dirname, 'workspaces/extending'));
+
+		assert.strictEqual(optsAndFiles.mochaOpts.ui, "tdd");
+
+		assert.ok(optsAndFiles.mochaOpts.asyncOnly);
+	})
 });

--- a/src/test/workspaces/extending/.mocharc.jsonc
+++ b/src/test/workspaces/extending/.mocharc.jsonc
@@ -1,0 +1,4 @@
+{
+	"extends": "./base.json",
+	"ui": "tdd"
+}

--- a/src/test/workspaces/extending/base.json
+++ b/src/test/workspaces/extending/base.json
@@ -1,0 +1,3 @@
+{
+    "asyncOnly": true
+}

--- a/src/worker/loadConfig.ts
+++ b/src/worker/loadConfig.ts
@@ -1,3 +1,12 @@
 import { loadOptions } from 'mocha/lib/cli/options';
+import * as yargs from "yargs";
 
-process.send!(loadOptions(process.argv.slice(2)));
+let args: yargs.Arguments = loadOptions(process.argv.slice(2)) as any;
+
+(
+	async () => {
+		process.send!(
+			yargs.parserConfiguration(
+				require("mocha/lib/cli/options").YARGS_PARSER_CONFIG ?? {}).config(
+					args).parse(args._ as any));
+	})();


### PR DESCRIPTION
Currently, `mocha`s `import("mocha/lib/cli/options").loadOptions` function does not respect the `extends` setting.

Rather, config inheritance is handled separately in `mocha/lib/cli/cli`:
https://github.com/mochajs/mocha/blob/37deed262d4bc0788d32c66636495d10038ad398/lib/cli/cli.js#L49-L79

Notice the `import("yargs").config()` call in the linked snippet.

To address this issue, changes to `loadConfig` have been made to replicate `mocha`s behavior:
https://github.com/manuth/vscode-mocha-test-adapter/blob/aa7ec47884ffb8c82885ee7c1942bbecd6596056/src/worker/loadConfig.ts#L4-L12

Changes made in this PR will fix #223