### PR TITLE
Fix extension category in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/hbenl/vscode-mocha-test-adapter/issues"
   },
   "categories": [
-    "Other"
+    "Testing"
   ],
   "keywords": [
     "mocha",


### PR DESCRIPTION
This allows for the extension to be discoverable in VS Code marketplace using query `@category:"testing"` similar to other testing extensions.