### PR TITLE
disable mocha parallel mode if tests are being debugged

### DIFF
--- a/src/worker/main.ts
+++ b/src/worker/main.ts
@@ -158,7 +158,7 @@ async function execute(args: WorkerArgs, sendMessage: (message: any) => Promise<
 		if (args.mochaOpts.delay) mocha.delay();
 		if (args.mochaOpts.fullTrace) mocha.fullTrace();
 		if (args.mochaOpts.asyncOnly) mocha.asyncOnly();
-		if (mocha.parallelMode) {
+		if (!args.debuggerPort && mocha.parallelMode) {
 			mocha.parallelMode(args.mochaOpts.parallel);
 			if (args.mochaOpts.jobs !== undefined) {
 				mocha.options.jobs = args.mochaOpts.jobs;


### PR DESCRIPTION
If mocha is set to run in parallel mode, then breakpoints in test code fail to be hit. This is because mocha itself tries to run tests using worker pool, while debugger is waiting on main mocha thread. 

Parallel mode in general does not make sense while trying to debug tests using this extension. Ignoring parallel mode setting while running the tests in debug mode fixes the breakpoint problem.